### PR TITLE
Now refering to https version of particles.js

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -64,7 +64,7 @@
     </script>
     {{end}}
 <div id="particles-js"></div>
-<script src="http://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
+<script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
 <script src="{{ .Site.BaseURL }}js/particles.js"></script>   
 </head>
 <body class="nav-closed">


### PR DESCRIPTION
If hosting this site on an HTTPS environment this'd trigger warnings, and not-loading the script, about mixed content.

This ought to fix that.